### PR TITLE
Download first source when multiple URLs are given

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -111,7 +111,7 @@ for (pkg in packages) {
 
       make_remote_tarball(
         remote_info[["package"]],
-        remote_info[["sources"]][[1]],
+        remote_info[["sources"]][[1]][[1]],
         remote_target
       )
     }


### PR DESCRIPTION
Avoids the following occasional error,

```
Error in download.file(url, source_tarball) : 
  'url' must be a length-one character vector
```