### PR TITLE
Delete lib/pkg dir before attempting to move there

### DIFF
--- a/webr-build.sh
+++ b/webr-build.sh
@@ -31,6 +31,9 @@ $R_HOST/bin/R CMD INSTALL --build --library="lib" "${PKG_NAME}" \
   --no-staged-install \
   --no-byte-compile
 
+if [ -d "${ROOT}/lib/${PKG_NAME}" ]; then
+  rm -rf "${ROOT}/lib/${PKG_NAME}"
+fi
 mv lib/* ${ROOT}/lib
 
 BIN="${ORIG}/repo/bin/emscripten/contrib/${R_VERSION}/"


### PR DESCRIPTION
Avoids the following occasional error when building a package multiple times.

```
mv: rename lib/pkg to /[...]/webr-repo/lib/pkg: Directory not empty
```

I originally had this check that `ROOT` and `PKG_NAME` are defined to avoid issues with `rm`, but `set -eu` at the top of the script takes care of that for us.