### PR TITLE
Explicitly set R_HOME for wasm build

### DIFF
--- a/webr-vars.mk
+++ b/webr-vars.mk
@@ -7,6 +7,7 @@
 
 R_VERSION = $(shell cat $(WEBR_ROOT)/R/R-VERSION)
 R_SOURCE = $(WEBR_ROOT)/R/build/R-$(R_VERSION)
+R_HOME = $(WEBR_ROOT)/wasm/R-$(R_VERSION)/lib/R
 
 WEBR_INCLUDES = -I$(R_SOURCE)/build/include -I$(R_SOURCE)/src/include
 WEBR_LDFLAGS = -L$(WEBR_ROOT)/wasm/lib -L$(WEBR_ROOT)/wasm/R-$(R_VERSION)/lib/R/lib


### PR DESCRIPTION
Avoids a patch to the Matrix package that uses `$(R_HOME)` in its `Makevars` file.