### PR TITLE
Use rlang from CRAN

### DIFF
--- a/repo-remotes
+++ b/repo-remotes
@@ -3,6 +3,5 @@ r-wasm/cli@webr
 r-wasm/data.table@webr
 r-wasm/glue@webr
 r-wasm/mgcv@webr
-r-wasm/rlang@webr
 r-wasm/svglite@webr
 r-wasm/testthat@webr


### PR DESCRIPTION
The latest rlang on CRAN now seems to work OK without requiring a patch.