### PR TITLE
Ignore non-CRAN packages when looking up package versions in `cran_info`

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -83,8 +83,9 @@ tarball <- function(pkg, ver) {
 }
 
 cran_info <- available.packages()
-versions <- cran_info[packages, "Version", drop = TRUE]
-names(versions) <- packages
+cran_packages <- packages[!(packages %in% remotes_packages)]
+versions <- cran_info[cran_packages, "Version", drop = TRUE]
+names(versions) <- cran_packages
 versions[remotes_packages] <- remotes_info[["version"]]
 
 need_update <- FALSE


### PR DESCRIPTION
Avoids an error when non-cran packages are added to the `repo-packages` list.