### PR TITLE
Update packages installed in host R if the current version doesn't match

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -127,7 +127,7 @@ for (pkg in packages) {
     download.file(new_url, tarball_path)
   }
 
-  if (!pkg %in% host_packages || packageVersion(pkg) != new_ver_string) {
+  if (!pkg %in% host_packages || packageVersion(pkg) < new_ver_string) {
     install.packages(pkg)
   }
 

--- a/repo-update.R
+++ b/repo-update.R
@@ -127,7 +127,7 @@ for (pkg in packages) {
     download.file(new_url, tarball_path)
   }
 
-  if (!pkg %in% host_packages) {
+  if (!pkg %in% host_packages || packageVersion(pkg) != new_ver_string) {
     install.packages(pkg)
   }
 


### PR DESCRIPTION
I needed this to avoid errors such as, `namespace ‘vctrs’ 0.5.2 is being loaded, but >= 0.6.0 is required`, when upgrading sets of packages already installed in the host R.