### PR TITLE
Fixing typos

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -125,7 +125,7 @@ for (pkg in packages) {
   } else {
     tarball_file <- tarball(pkg, new_ver_string)
     tarball_path <- file.path(webr_contrib_src, tarball_file)
-    new_url <- paste0(cran_url, "src/contrib/", tarball_file)
+    new_url <- paste0(cran_url, "/src/contrib/", tarball_file)
     download.file(new_url, tarball_path)
   }
 

--- a/webr-build.sh
+++ b/webr-build.sh
@@ -38,7 +38,7 @@ mv lib/* ${ROOT}/lib
 BIN="${ORIG}/repo/bin/emscripten/contrib/${R_VERSION}/"
 
 mkdir -p $BIN
-mv *.tgz $BIN
+mv *.tar.gz $BIN
 
 cd ${ORIG}
 rm -rf ${TMP}


### PR DESCRIPTION
Hi, thanks for this amazing work!
I managed to build libraries through `mage pkg-xxx` but I had to fix 2 lines:
- the source package url was missing a `/`
- packaged libraries were genrerated with `the .tar.gz` extension instead of the expected `.tgz`

I don't know if it was typos or configuration divergence?
Here is my setup :
- a simple `rocker/r-ver:4.3.0` Docker image
- host : Ubuntu 22.04
- repo files were mounted as a volume
- I manually set R_HOST, R_VERSION and R_VERSION_SHORT in Makefile
- command: `make pkg-xxx`

